### PR TITLE
Adds 'target' option which allows users to append the created styleSelect elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Where `selector` is a CSS selector and `element` is an HTML Element or NodeList.
 
 That's all. From then on you'll probably want to tweak styling.
 
+#### Options 
+
+`target` 
+    
+Appends the styled select box to a custom container.
+
+    styleSelect(
+        element, 
+        {
+            target: this.container
+        }
+    );
+
+
 ## Credit
 
 Style Select is based on [VisualSelect](https://github.com/LeslieOA/VisualSelect), created for Multplx Attract platform.

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ That's all. From then on you'll probably want to tweak styling.
 
 #### Options 
 
-`target` 
-    
-Appends the styled select box to a custom container.
+`target: HTML Element` 
+
+Appends the styled select box to a custom container. 
 
     styleSelect(
         element, 
         {
-            target: this.container
+            target: container
         }
     );
 

--- a/js/styleselect.js
+++ b/js/styleselect.js
@@ -151,7 +151,11 @@
 
 	// The 'styleSelect' main function
 	// selector:String - CSS selector for the select box to style
-	return function(selector) {
+	return function(selector, options) {
+
+		var settings = {
+			target: options.target,
+		};
 
 		// Use native selects (which pop up large native UIs to go through the options ) on iOS/Android
 		if ( navigator.userAgent.match( /iPad|iPhone|Android/i ) ) {
@@ -197,8 +201,13 @@
 		});
 		optionsHTML += '</div>';
 		styleSelectHTML += selectedOptionHTML += optionsHTML += '</div>';
-		// And add out styled select just after the real select
-		realSelect.insertAdjacentHTML('afterend', styleSelectHTML);
+		
+		// And add out styled select just after the real select if no target is set
+		if(settings.target){
+			settings.target.insertAdjacentHTML('beforeend', styleSelectHTML);	
+		} else{
+			realSelect.insertAdjacentHTML('afterend', styleSelectHTML);
+		}
 
 		var styledSelect = query('.style-select[data-ss-uuid="'+uuid+'"]');
 		var styleSelectOptions = styledSelect.querySelectorAll('.ss-option');

--- a/js/styleselect.js
+++ b/js/styleselect.js
@@ -152,11 +152,15 @@
 	// The 'styleSelect' main function
 	// selector:String - CSS selector for the select box to style
 	return function(selector, options) {
+		
+		var settings = {}
 
-		var settings = {
-			target: options.target,
-		};
-
+		if(options){
+			settings = {
+				target: options.target,
+			};
+		}
+	
 		// Use native selects (which pop up large native UIs to go through the options ) on iOS/Android
 		if ( navigator.userAgent.match( /iPad|iPhone|Android/i ) ) {
 			return


### PR DESCRIPTION
A 'target' option allows users to append the created styleSelect element into another element of their choice. 

I made the 'target' option the first of a 'options/settings' object that can be extended for future options. 

I added the 'target' option for myself while using styleSelect with Wordpress/WooCommerce product variation forms. 

I wanted to escape WooCommerce's outdated form markup and take my awesome styleSelect drop-downs to my own container where I could arrange them painlessly. 

**PR**'ing so others can use this option if it fits their case.

The README has also been updated to explain how one would use this setting. 